### PR TITLE
Add availability guard to function

### DIFF
--- a/src/unix/darwin-stub.h
+++ b/src/unix/darwin-stub.h
@@ -112,8 +112,13 @@ static const int kFSEventStreamEventFlagUnmount = 128;
 static const int kFSEventStreamEventFlagUserDropped = 2;
 
 /* Copied from https://opensource.apple.com/source/xnu/xnu-6153.101.6/libsyscall/wrappers/spawn/spawn_private.h.auto.html */
-int posix_spawnattr_set_uid_np(const posix_spawnattr_t*, uid_t);
-int posix_spawnattr_set_gid_np(const posix_spawnattr_t*, gid_t);
-int posix_spawnattr_set_groups_np(const posix_spawnattr_t*, int, gid_t*, uid_t);
+int posix_spawnattr_set_uid_np(const posix_spawnattr_t*, uid_t)
+__API_AVAILABLE(macos(10.15), ios(13.0), tvos(13.0), watchos(6.0));
+
+int posix_spawnattr_set_gid_np(const posix_spawnattr_t*, gid_t)
+__API_AVAILABLE(macos(10.15), ios(13.0), tvos(13.0), watchos(6.0));
+
+int posix_spawnattr_set_groups_np(const posix_spawnattr_t*, int, gid_t*, uid_t)
+__API_AVAILABLE(macos(10.15), ios(13.0), tvos(13.0), watchos(6.0));
 
 #endif  /* UV_DARWIN_STUB_H_ */

--- a/src/unix/process.c
+++ b/src/unix/process.c
@@ -349,7 +349,8 @@ static void uv__process_child_init(const uv_process_options_t* options,
 int uv__spawn_and_init_child_posix_spawn(const uv_process_options_t* options,
                                          int stdio_count,
                                          int (*pipes)[2], 
-                                         pid_t* pid) {
+                                         pid_t* pid) 
+                                         __API_AVAILABLE(macos(10.15)) {
   int fd;
   int err;
   sigset_t signal_set;


### PR DESCRIPTION
Fixes this error when building Electron:

```
../../third_party/electron_node/deps/uv/src/unix/process.c:411:31: error: 'posix_spawn_file_actions_addchdir_np' is only available on macOS 10.15 or newer [-Werror,-Wunguarded-availability-new]
  if (options->cwd != NULL && posix_spawn_file_actions_addchdir_np(&actions, options->cwd))
                              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../../../../../../../.electron_build_tools/third_party/Xcode/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.0.sdk/usr/include/spawn.h:178:9: note: 'posix_spawn_file_actions_addchdir_np' has been marked as being introduced in macOS 10.15 here, but the deployment target is macOS 10.10.0
int     posix_spawn_file_actions_addchdir_np(posix_spawn_file_actions_t *,
        ^
../../third_party/electron_node/deps/uv/src/unix/process.c:411:31: note: enclose 'posix_spawn_file_actions_addchdir_np' in a __builtin_available check to silence this warning
  if (options->cwd != NULL && posix_spawn_file_actions_addchdir_np(&actions, options->cwd))
                              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```